### PR TITLE
feat: add includes feature

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
     description: Set to `all` to return all modules or `changed` to only return modules that have changes in this PR/commit. Defaults to `changed`.
     required: false
     default: changed
+  includes:
+    description: List of module path globs to include. Uses gitignore spec.
+    required: false
   ignore:
     description: List of module path globs to ignore. Uses gitignore spec.
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ async function run(): Promise<void> {
     const token = core.getInput('token', { required: true })
     const mode = core.getInput('mode', { required: true })
     const ignored = core.getInput('ignore')
+    const includes = core.getInput('includes')
     const monitored = core
       .getInput('monitored')
       .split(',')
@@ -31,6 +32,14 @@ async function run(): Promise<void> {
     if (ignored) {
       const globs = ignored.split('\n').map((item) => item.trim())
       modules = ignore().add(globs).filter(modules)
+    }
+
+    if (includes) {
+      const globs = includes.split('\n').map((item) => item.trim())
+      const filteredModules = modules.filter(module => module !== null && module !== undefined && module !== "");
+      const ignores = ignore().add(globs)
+
+      modules = filteredModules.filter(module => ignores.ignores(module));
     }
 
     if (modules.length) {


### PR DESCRIPTION
This include parameter allows you to specify certain folder patterns to include only terraform modules that match the pattern.